### PR TITLE
Add documentation for setting up slack

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -48,23 +48,26 @@ DJANGO_SETTINGS_MODULE=config.settings.local
 
 # This defines the slack channel to import users from.
 # DJANGO_SLACK_CHANNEL_NAME="public-slack-channel"
+
 # This defines the slack token used when sending API requests from the server
 # to fetch users using the slack importers. This is bot token, identified by the 
 # xoxb- prefix. You can get this from the slack admin panel
-
 # DJANGO_SLACK_TOKEN="xoxb-111111111111-1111111111111-x1x1x1x1x1x1x1x1x1x1x1x1"
 
-# These define the client id, secret, token, and authorize url used by allauth's 
+# These define the client id, secret, token, and authorize url used by the allauth  
 # social login to connect to slack.
-
-# This is a slack user token, identified by the xoxp- prefix. You can get this from
-# the slack admin panel 
-# DJANGO_SLACK_USER_TOKEN="xoxp-111111111111-111111111111-1111111111111-x1x1x1x1x1x1x1x1x1x1x1x1x1x1x1x1"
 # DJANGO_SLACK_SIGNIN_AUTHORIZE_URL="https://your-slack-workspace.slack.com/openid/connect/authorize"
+# DJANGO_SLACK_CLIENT_ID="111111111111.1111111111111"
+# DJANGO_SLACK_SECRET="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+# DJANGO_SLACK_USER_TOKEN="xoxp-111111111111-111111111111-1111111111111-x1x1x1x1x1x1x1x1x1x1x1x1x1x1x1x1"
+
 
 # Thse define the airtables used to pull data down for profiles and import.
 # the BEARER token is send with every API request, and the BASE and TABLE
 # identify the airtable and the table within it to connect fetch data from
+DJANGO_AIRTABLE_BEARER_TOKEN="xxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+DJANGO_AIRTABLE_BASE="appxxxxxxxxxxxxxx"
+DJANGO_AIRTABLE_TABLE="tblxxxxxxxxxxxxxx"
 
 # Setting this stops python creating .pyc files in the workspace
 PYTHONDONTWRITEBYTECODE=1

--- a/docs/setting-up-slack.md
+++ b/docs/setting-up-slack.md
@@ -1,0 +1,55 @@
+# Slack support
+
+Constellate integrates into slack in two main ways. 
+
+1. It is designed to support users in a slack workspace signing in using the same credentials they used to sign into the slack, allowing you to restrict access to members of a particular slack.
+
+2. It can import from a specified channel into an instance, to pre-populate a directory with users, profile photo and other information in slack.
+
+## Sign In via slack
+
+To support sign-in via slack, you need to create an slack app, on the slack developer site, at the link below:
+
+https://api.slack.com/apps
+
+Once you've created an app, you'll need to set the following environment variables to identify, and authenticate your application when redirecting users to slack to sign in.
+
+```
+DJANGO_SLACK_CLIENT_ID="xxxxxxxxxxxx.xxxxxxxxxxxxx"
+DJANGO_SLACK_SECRET="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+```
+
+You'll also need to set the correct worksapce to send users to when signing in, so they sign into the correct workspace:
+
+```
+DJANGO_SLACK_SIGNIN_AUTHORIZE_URL="https://your-workspace-name.slack.com/openid/connect/authorize"
+```
+
+With these set up, users will be able to sign using their slack credentials.
+
+
+## Import users from a channel
+
+In addition to creating users when they sign in via slack, it's possible to create batches of users, by importing all the members in a named channel.
+
+This requires _different_ tokens with slack, because rather than using OAuth, to allow a user to sign in on behalf of a user, it is the _application_ itself connecting to the slack API and fetching information. The importer uses a _bot token_ identifiable by the first few characters showing as `xoxb-`:
+
+```
+DJANGO_SLACK_TOKEN="xoxb-xxxxxxxxxxxx-xxxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxx"
+```
+
+You also need to identify a specific channel to import users from: 
+
+```
+DJANGO_SLACK_CHANNEL_NAME="my-fave-channel"
+```
+
+Once these are set, you can import all the users in the specified channel using the following management command:
+
+```
+./manage.py import_users_from_slack
+```
+
+Once you have run the import, the users with their profile photos will be visible in the running constellate instance.
+
+_**Note**_: this is intended for groups of less than 100 users. _No attempt_ has been made to make this work for importing large channels in the hundreds or thousands of users, and using it will likely get you rate limited.


### PR DESCRIPTION
This PR adds the documentation for people setting up the link between a constellate instance and a slack workspace