### PR TITLE
Add support for one way sync from Airtable

### DIFF
--- a/cl8/conftest.py
+++ b/cl8/conftest.py
@@ -17,6 +17,7 @@ from cl8.users.tests.factories import (
 
 register(UserFactory)
 register(FakePhotoProfileFactory)
+register(ProfileFactory)
 
 
 @pytest.fixture(autouse=True)

--- a/cl8/conftest.py
+++ b/cl8/conftest.py
@@ -12,12 +12,14 @@ from cl8.users.models import Constellation, Profile, User
 from cl8.users.tests.factories import (
     FakePhotoProfileFactory,
     ProfileFactory,
+    ProfileUserFactory,
     UserFactory,
 )
 
 register(UserFactory)
 register(FakePhotoProfileFactory)
 register(ProfileFactory)
+register(ProfileUserFactory)
 
 
 @pytest.fixture(autouse=True)

--- a/cl8/templates/_profile.html
+++ b/cl8/templates/_profile.html
@@ -72,7 +72,15 @@
                 <button type="submit" class="btn btn-sm mt-2 mb-2 max-w-xs">Import CAT Joiningform Info</button>
             </form>
         {% endflag %}
-    {% endif %}
+        {% flag "cat_airtable_import" %}
+        <form action="{% url 'profile-cat-airtable-import' profile.short_id %}"
+              method="post"
+              class="inline-block">
+            {% csrf_token %}
+            <button type="submit" class="btn btn-sm mt-2 mb-2 max-w-xs">Import CAT Directory Data Info</button>
+        </form>
+    {% endflag %}
+{% endif %}
 </div>
 </div>
 <div class="px-0">

--- a/cl8/templates/pages/_paginated_profiles.html
+++ b/cl8/templates/pages/_paginated_profiles.html
@@ -13,7 +13,9 @@
            hx-push-url="true">
         <div class="profile-thumb w-1/5">
           {% if profile.photo %}
-            <img src="{{ profile.thumbnail_photo }}"  class="rounded" />
+            <img src="{{ profile.thumbnail_photo }}"
+                 class="rounded"
+                 alt="Profile photo for {{ profile.name }}" />
           {% else %}
             {% gravatar profile.user.email 150 "Profile via gravatar.com" "rounded" %}
           {% endif %}

--- a/cl8/templates/pages/home.html
+++ b/cl8/templates/pages/home.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
-{% load static widget_tweaks %}
+{% load static widget_tweaks daisy_helpers %}
 {% block content %}
-<style>
+  <style>
   dialog {
     /* Override some builtins that limit us: */
     max-width: 70vw;
@@ -26,108 +26,100 @@
   dialog::backdrop {
     background-color: #0008;
   }
-</style>
-<main>
-  {% comment %} add our search component spanning the full width {% endcomment %}
-  <section class="search-component grid grid-cols-[1fr_minmax(auto,70rem)_1fr]">
-    {% comment %} we have two sets of empty divs either side of our main search component to center it {% endcomment %}
-    {% comment %} djlint:off{% endcomment %}
+  </style>
+  <main>
+    {% comment %} add our search component spanning the full width {% endcomment %}
+    <section class="search-component grid grid-cols-[1fr_minmax(auto,70rem)_1fr]">
+      {% comment %} we have two sets of empty divs either side of our main search component to center it {% endcomment %}
+      {% comment %} djlint:off{% endcomment %}
     <div></div>
-    {% comment %} djlint:on {% endcomment %}
-    <section>
-      <div class="card search-block border rounded-none">
-        <div class="card-body">
-          <form id="filter-form" method="get" hx-get="/" hx-trigger="submit, htmx:confirm from:#id_tags, htmx:confirm from:#id_bio, toggle-tag from:body" hx-target=".sidebar" hx-push-url="true">
-            <div class="grid grid-cols-1 lg:grid-cols-[1fr_10rem]">
-              <div>
-                {% comment %} <p>
-                  <label class="inline-block w-100 mr-8 text-xl"
-                    for="{{ profile_filter.form.bio.id_for_label }}">Showing profile results matching:</label>
-                </p> {% endcomment %}
-
-                {% comment %} we need these all on one line for the render_field template tag {% endcomment %}
-                {% render_field profile_filter.form.bio hx-get="/" hx-trigger="keyup changed delay:0.1s" hx-target=".sidebar" class="text-xl min-w-[100%]" hx-sync="closest form:abort" %}
-              </div>
-              <div>
-                <button class="btn mt-4 lg:mt-0 lg:ml-4" type="submit">Search</button>
-              </div>
-            </div>
-            <span class="hidden">{% render_field profile_filter.form.tags %}</span>
-          </form>
-          <div class="active-tags">{% include "_active_tags_list.html" %}</div>
-          <div class="profile-count">
-            {% if active_search %}
-            <p class="text-xl inline-block ">
-              <span data-profile-count="{{ paginated_profiles|length }}">{{ paginated_profiles|length }}</span> matching
-              profile{{ paginated_profiles|pluralize }} found
-            </p>
-            {% endif %}
-          </div>
-          <div class="messages">
-              {% if messages %}
-              <ul class="messages">
-                  {% for message in messages %}
-                  <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
-                  {% endfor %}
-              </ul>
-              {% endif %}
-            </div>
-        </div>
-      </div>
-    </section>
-    {% comment %} djlint:off{% endcomment %}
+{% comment %} djlint:on {% endcomment %}
+<section>
+<div class="card search-block border rounded-none">
+<div class="card-body">
+<form id="filter-form" method="get" hx-get="/" hx-trigger="submit, htmx:confirm from:#id_tags, htmx:confirm from:#id_bio, toggle-tag from:body" hx-target=".sidebar" hx-push-url="true">
+<div class="grid grid-cols-1 lg:grid-cols-[1fr_10rem]">
+<div>
+{% comment %} <p>
+                  <label class="inline-block w-100 mr-8 text-xl" for="{{ profile_filter.form.bio.id_for_label }}">Showing profile results matching:</label>
+</p> {% endcomment %}
+{% comment %} we need these all on one line for the render_field template tag {% endcomment %}
+{% render_field profile_filter.form.bio hx-get="/" hx-trigger="keyup changed delay:0.1s" hx-target=".sidebar" class="text-xl min-w-[100%]" hx-sync="closest form:abort" %}
+</div>
+<div>
+<button class="btn mt-4 lg:mt-0 lg:ml-4" type="submit">Search</button>
+</div>
+</div>
+<span class="hidden">{% render_field profile_filter.form.tags %}</span>
+</form>
+<div class="active-tags">{% include "_active_tags_list.html" %}</div>
+<div class="profile-count">
+{% if active_search %}
+<p class="text-xl inline-block ">
+<span data-profile-count="{{ paginated_profiles|length }}">{{ paginated_profiles|length }}</span> matching
+profile{{ paginated_profiles|pluralize }} found
+</p>
+{% endif %}
+</div>
+<div class="messages">
+{% if messages %}
+<ul class="messages">
+{% for message in messages %}
+<li {% if message.tags %}class="border p-2 {{ message.tags|message_tag_to_color }}"{% endif %}>{{ message }}</li>
+{% endfor %}
+</ul>
+{% endif %}
+</div>
+</div>
+</div>
+</section>
+{% comment %} djlint:off{% endcomment %}
     <div></div>
-    {% comment %} djlint:on {% endcomment %}
-    {% comment %} close search component {% endcomment %}
-  </section>
-  {% comment %} main content {% endcomment %}
-  <section class="grid grid-cols-[1fr_minmax(auto,70rem)_1fr]">
-    {% comment %} djlint:off{% endcomment %}
+{% comment %} djlint:on {% endcomment %}
+{% comment %} close search component {% endcomment %}
+</section>
+{% comment %} main content {% endcomment %}
+<section class="grid grid-cols-[1fr_minmax(auto,70rem)_1fr]">
+{% comment %} djlint:off{% endcomment %}
     <div></div>
-    {% comment %} djlint:on {% endcomment %}
-    {% comment %} add our two columns for the sidebar and profile {% endcomment %}
-    <section class="column-wrapper  grid grid-cols-1 lg:grid-cols-3">
-      {% comment %} list the active tags
-      {% endcomment %}
-      {% comment %}
+{% comment %} djlint:on {% endcomment %}
+{% comment %} add our two columns for the sidebar and profile {% endcomment %}
+<section class="column-wrapper  grid grid-cols-1 lg:grid-cols-3">
+{% comment %} list the active tags
+{% endcomment %}
+{% comment %}
       We only want to hide the list of profiles when there is NO filtered search
       and when a user is not selected.
-      {% endcomment %}
-      <div class="sidebar transition-all border {% if hide_profile_list %}hidden{% endif %} lg:inline"
-        style="max-height: 100vh">
-        {% include "pages/_paginated_profiles.html" %}
-      </div>
-      <div id="profile-slot"
-        class="card bg-base-100 lg:col-span-2 border rounded-none {% if not hide_profile_list %}hidden{% endif %} lg:inline"
-        hx-trigger="save-profile-change from:body" hx-get="." hx-target="#profile-slot" hx-swap="innerHTML">
-        {% if profile %}
-        {% comment %} show the profile with all the tags, and details {% endcomment %}
-        {% include "_profile.html" %}
-        {% else %}
-        {% comment %} otherwise show a blank "start" view with instructions {% endcomment %}
-        {% include "_profile_empty.html" %}
-        {% endif %}
-      </div>
-    </section>
-    {% comment %} djlint:off{% endcomment %}
+{% endcomment %}
+<div class="sidebar transition-all border {% if hide_profile_list %}hidden{% endif %} lg:inline" style="max-height: 100vh">
+{% include "pages/_paginated_profiles.html" %}
+</div>
+<div id="profile-slot" class="card bg-base-100 lg:col-span-2 border rounded-none {% if not hide_profile_list %}hidden{% endif %} lg:inline" hx-trigger="save-profile-change from:body" hx-get="." hx-target="#profile-slot" hx-swap="innerHTML">
+{% if profile %}
+{% comment %} show the profile with all the tags, and details {% endcomment %}
+{% include "_profile.html" %}
+{% else %}
+{% comment %} otherwise show a blank "start" view with instructions {% endcomment %}
+{% include "_profile_empty.html" %}
+{% endif %}
+</div>
+</section>
+{% comment %} djlint:off{% endcomment %}
     <div></div>
-    {% comment %} djlint:on {% endcomment %}
-    {% comment %} close maint content section {% endcomment %}
-  </section>
-  {% comment %}
+{% comment %} djlint:on {% endcomment %}
+{% comment %} close maint content section {% endcomment %}
+</section>
+{% comment %}
   Add hidden version of empty profile content, used when clearing a select
   profile
-  {% endcomment %}
-  <div id="empty-profile" class="hidden">{% include "_profile_empty.html" %}</div>
+{% endcomment %}
+<div id="empty-profile" class="hidden">{% include "_profile_empty.html" %}</div>
 </main>
 {% endblock content %}
 {% block scripts %}
 {{ block.super }}
-
 {{ profile_filter.form.media }}
-
 <script src="{% static 'js/htmx.v1.9.10.min.js' %}" defer></script>
-
 <script>
   document.addEventListener("DOMContentLoaded", (event) => {
     console.debug("DOM fully loaded and parsed");

--- a/cl8/users/forms.py
+++ b/cl8/users/forms.py
@@ -7,7 +7,7 @@ from django.core.exceptions import ValidationError
 from django.forms import ModelMultipleChoiceField
 from django.utils.translation import gettext_lazy as _
 from taggit import models as taggit_models
-
+from .widgets import CustomClearableFileInput
 from .importers import safe_username
 from .models import Profile
 
@@ -36,9 +36,6 @@ class UserCreationForm(auth_forms.UserCreationForm):
             return username
 
         raise ValidationError(self.error_messages["duplicate_username"])
-
-
-from .widgets import CustomClearableFileInput
 
 
 class ProfileUpdateForm(forms.ModelForm):

--- a/cl8/users/importers.py
+++ b/cl8/users/importers.py
@@ -589,6 +589,10 @@ class CATAirtableImporter:
         profile.bio = fields.get("bio")
         profile.visible = True
 
+        airtable_id = row.get("id")
+        profile.import_id = f"airtable-"{airtable_id}"
+
+
         self.add_tags_to_profile(profile, fields)
         profile.save()
         profile.update_thumbnail_urls()
@@ -635,6 +639,10 @@ class CATAirtableImporter:
         profile.linkedin = fields.get("LinkedIn URL")
         profile.visible = True
 
+        if not profile.import_id:
+            airtable_id = row.get("id")
+            profile.import_id = f"airtable-"{airtable_id}"
+
         self.add_tags_to_profile(profile, fields)
         profile.save()
         # create different sized variants of the thumbnail
@@ -656,6 +664,7 @@ class CATAirtableImporter:
                 "Asks",
                 "Specific skills",
                 "Areas of focus",
+                "Climate Interests",
             ]
 
         for colname in columns:

--- a/cl8/users/importers.py
+++ b/cl8/users/importers.py
@@ -618,7 +618,7 @@ class CATAirtableImporter:
     def update_profile_for_row(self, row: dict):
         """
         Update profile for the given row, matching on the
-        email address. Adds the inrromation listed in
+        email address. Adds the information listed in
         self.expected_rows
         """
         fields = row.get("fields")

--- a/cl8/users/importers.py
+++ b/cl8/users/importers.py
@@ -17,6 +17,7 @@ from cl8.users.models import CATJoinRequest
 
 from ..utils.pics import fetch_user_pic
 from .models import Profile, User
+import json
 
 logger = logging.getLogger(__file__)
 logger.setLevel(logging.INFO)
@@ -516,6 +517,17 @@ class CATAirtableImporter:
         rows = table.all()
         self.rows = rows
         return rows
+
+    def dump_data_to_json_file(self, filename: str = "airtable-directory.json"):
+        """
+        Fetch data in airtable, and write it to a local json file.
+        Used for testing to avoid making needless API calls.
+        """
+        local_airtable_data_path = settings.PROJECT_DIR / "data" / filename
+
+        data = self.fetch_data_from_airtable()
+        with open(str(local_airtable_data_path), "w") as f:
+            f.write(json.dumps(data, indent=4))
 
     def fetch_user_data_from_airtable_by_email(self, email) -> Optional[dict]:
         """

--- a/cl8/users/importers.py
+++ b/cl8/users/importers.py
@@ -590,8 +590,7 @@ class CATAirtableImporter:
         profile.visible = True
 
         airtable_id = row.get("id")
-        profile.import_id = f"airtable-"{airtable_id}"
-
+        profile.import_id = f"airtable-{airtable_id}"
 
         self.add_tags_to_profile(profile, fields)
         profile.save()
@@ -641,7 +640,7 @@ class CATAirtableImporter:
 
         if not profile.import_id:
             airtable_id = row.get("id")
-            profile.import_id = f"airtable-"{airtable_id}"
+            profile.import_id = f"airtable-{airtable_id}"
 
         self.add_tags_to_profile(profile, fields)
         profile.save()

--- a/cl8/users/models.py
+++ b/cl8/users/models.py
@@ -1,21 +1,21 @@
+import logging
+
+import vobject
 from django.conf import settings
 from django.contrib.auth.models import AbstractUser
+from django.contrib.sites.models import Site
 from django.core.mail import send_mail
 from django.db import models
 from django.db.models import CharField
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
-from django.contrib.sites.models import Site
+from shortuuid.django_fields import ShortUUIDField
 from sorl.thumbnail import get_thumbnail
 from taggit.managers import TaggableManager
 from taggit.models import TagBase, TaggedItemBase
-from django.contrib.sites.models import Site
-from shortuuid.django_fields import ShortUUIDField
-import vobject
-from ..utils import vcard_util
-import logging
 
+from ..utils import vcard_util
 
 logger = logging.getLogger(__name__)
 

--- a/cl8/users/templatetags/daisy_helpers.py
+++ b/cl8/users/templatetags/daisy_helpers.py
@@ -1,4 +1,3 @@
-from django.template.defaultfilters import yesno
 from django import template
 
 register = template.Library()

--- a/cl8/users/templatetags/daisy_helpers.py
+++ b/cl8/users/templatetags/daisy_helpers.py
@@ -1,0 +1,20 @@
+from django.template.defaultfilters import yesno
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def message_tag_to_color(value):
+    """
+    Custom template filter that acts like the builtin "yesno" filter,
+    but is only applied to certain values: explicitly True, False, None and "".
+    """
+    matching_color = {
+        "success": "green",
+        "info": "blue",
+        "warning": "yellow",
+        "error": "red",
+    }.get(value, "grey")
+
+    return f"bg-{matching_color}-100"

--- a/cl8/users/templatetags/daisy_helpers.py
+++ b/cl8/users/templatetags/daisy_helpers.py
@@ -6,8 +6,11 @@ register = template.Library()
 @register.filter
 def message_tag_to_color(value):
     """
-    Custom template filter that acts like the builtin "yesno" filter,
-    but is only applied to certain values: explicitly True, False, None and "".
+    Custom template filter that converts a message tag to a color, so we can use
+    some of these default colors provided by Tailwind CSS provides, via
+    Daisy our UI library:
+    https://tailwindcss.com/docs/background-color
+    https://tailwindcss.com/docs/customizing-colors#default-color-palette
     """
     matching_color = {
         "success": "green",

--- a/cl8/users/tests/test_importer_airtable.py
+++ b/cl8/users/tests/test_importer_airtable.py
@@ -1,0 +1,138 @@
+import json
+import logging
+import pathlib
+
+import pytest
+from django.conf import settings
+
+
+from .. import importers, models
+
+logger = logging.getLogger(__file__)
+logger.setLevel(logging.INFO)
+
+
+@pytest.fixture
+def airtable_dummy_user():
+    return {
+        "id": "recs9I1teiTi4YGlT",
+        "createdTime": "2019-10-14T17:47:10.000Z",
+        "fields": {
+            "Climate Interests": [
+                "Environmental justice",
+                "Energy",
+                "New technology",
+                "Activism",
+            ],
+            "LinkedIn URL": "https://www.linkedin.com/in/mrchrisadams/",
+            "Email address": "chris@productscience.net",
+            "Specific skills": [
+                "Python",
+                "SQL",
+                "JavaScript",
+                "Ansible",
+                "Community building",
+            ],
+            "Location": "Berlin, DE (but anywhere train goes, really)",
+            "Moderation status": ["Approved"],
+            "Bio": "I am an organiser of CAT, and preoccupied with decoupling the cool bits of tech, from the crap bits of tech, like us using fossil fuels needlessly, and not questioning the unintended impacts we have",
+            "Offers": ["Strategic advice", "Mentoring"],
+            "Twitter": "mrchrisadams",
+            "Areas of focus": ["DevOps", "Web development", "Product", "UX design"],
+            "Slack name": "Chris Adams",
+            "Asks": ["Volunteers", "Funding", "Consulting"],
+            "Date added to directory": "2019-10-14",
+            "Record created time": "2019-10-14T17:47:10.000Z",
+            "Date updated": "2024-03-17",
+        },
+    }
+
+
+@pytest.fixture
+def users_from_airtable() -> list[dict]:
+    """
+    Return a list of airtable directory profiles as returned by calling
+    `fetch_data_from_airtable()` on the CATAirtableImporter against the
+    expected Airtable
+    """
+    # assuming you have sample local data
+    local_airtable_data = settings.PROJECT_DIR / "data" / "airtable-directory.json"
+    users = []
+
+    with open(local_airtable_data) as airtable_json:
+        data = airtable_json.read()
+        users.extend(json.loads(data))
+
+    return users
+
+
+class TestCATAirTableImporter:
+
+    @pytest.mark.skip(
+        reason="Just a sanity check to compare the airtable data with the dummy data"
+    )
+    def test_dummy_data_matches_airtable(
+        self, db, profile_user_factory, users_from_airtable, airtable_dummy_user
+    ):
+        importer = importers.CATAirtableImporter()
+        airtable_data = importer.fetch_data_from_airtable()
+
+        # enumerate through the airtable with an index
+        for index, user in enumerate(airtable_data):
+            assert user == users_from_airtable[index]
+
+        assert len(airtable_data) == len(users_from_airtable)
+
+    def test_create_user_from_airtable(self, db, airtable_dummy_user):
+        """Test that we add all the tags from the airtable user when creating a user and profile"""
+        importer = importers.CATAirtableImporter()
+
+        user = importer.create_user(airtable_dummy_user)
+        assert user.email == airtable_dummy_user["fields"]["Email address"]
+
+        tag_names = user.profile.tags.names()
+        groupings = [
+            "Climate Interests",
+            "Specific skills",
+            "Areas of focus",
+            "Offers",
+            "Asks",
+        ]
+
+        for grouping in groupings:
+            for skill in airtable_dummy_user["fields"][grouping]:
+                assert f"{grouping}:{skill}" in tag_names
+
+    @pytest.mark.only
+    def test_update_user_from_airtable(
+        self, db, airtable_dummy_user, user_factory, profile_factory
+    ):
+        """
+        Test that we add all the tags and info from the airtable user when creating a user and profile
+        """
+        importer = importers.CATAirtableImporter()
+
+        user = user_factory.create(email="chris@productscience.net")
+        profile = profile_factory.create(user=user)
+        assert profile == user.profile
+
+        assert user.email == airtable_dummy_user["fields"]["Email address"]
+
+        importer.update_profile_for_row(airtable_dummy_user)
+        profile.refresh_from_db()
+
+        tag_names = user.profile.tags.names()
+        groupings = [
+            "Climate Interests",
+            "Specific skills",
+            "Areas of focus",
+            "Offers",
+            "Asks",
+        ]
+
+        # do we have an import_id set so we know we have seen an update?
+        assert profile.import_id
+
+        for grouping in groupings:
+            for skill in airtable_dummy_user["fields"][grouping]:
+                assert f"{grouping}:{skill}" in tag_names

--- a/cl8/users/tests/test_importer_airtable.py
+++ b/cl8/users/tests/test_importer_airtable.py
@@ -67,8 +67,14 @@ def users_from_airtable() -> list[dict]:
 
 class TestCATAirTableImporter:
 
+    # this is just a sanity check to compare:
+    # a) actual data we can pull down from the CAT directory Airtable Base, to
+    # b) the dummy data we are using
+    #
+    # We don't run this each time but uncommenting it and running in the test suite
+    # ensures we are still using realistic dummy data for our tests
     @pytest.mark.skip(
-        reason="Just a sanity check to compare the airtable data with the dummy data"
+        reason="Used to sanity check dummy data against actual data from Airtable. See the code comments in the test for more."
     )
     def test_dummy_data_matches_airtable(
         self, db, profile_user_factory, users_from_airtable, airtable_dummy_user
@@ -77,10 +83,12 @@ class TestCATAirTableImporter:
         airtable_data = importer.fetch_data_from_airtable()
 
         # enumerate through the airtable with an index
-        for index, user in enumerate(airtable_data):
-            assert user == users_from_airtable[index]
+        profile_id = airtable_dummy_user["id"]
 
         assert len(airtable_data) == len(users_from_airtable)
+        matching_profile = [atd for atd in airtable_data if profile_id == atd["id"]]
+
+        assert matching_profile
 
     def test_create_user_from_airtable(self, db, airtable_dummy_user):
         """Test that we add all the tags from the airtable user when creating a user and profile"""
@@ -102,7 +110,6 @@ class TestCATAirTableImporter:
             for skill in airtable_dummy_user["fields"][grouping]:
                 assert f"{grouping}:{skill}" in tag_names
 
-    @pytest.mark.only
     def test_update_user_from_airtable(
         self, db, airtable_dummy_user, user_factory, profile_factory
     ):

--- a/cl8/users/tests/test_importer_airtable.py
+++ b/cl8/users/tests/test_importer_airtable.py
@@ -24,7 +24,7 @@ def airtable_dummy_user():
                 "Activism",
             ],
             "LinkedIn URL": "https://www.linkedin.com/in/mrchrisadams/",
-            "Email address": "chris@productscience.topleveldomain",
+            "Email address": "chris@example.com",
             "Specific skills": [
                 "Python",
                 "SQL",
@@ -155,7 +155,7 @@ class TestCATAirTableImporter:
         """
         importer = importers.CATAirtableImporter()
 
-        user = user_factory.create(email="chris@productscience.net")
+        user = user_factory.create(email="chris@example.com")
         profile = profile_factory.create(user=user)
         assert profile == user.profile
 

--- a/cl8/users/tests/test_importer_airtable.py
+++ b/cl8/users/tests/test_importer_airtable.py
@@ -1,12 +1,11 @@
 import json
 import logging
-import pathlib
 
 import pytest
 from django.conf import settings
 
 
-from .. import importers, models
+from .. import importers
 
 logger = logging.getLogger(__file__)
 logger.setLevel(logging.INFO)

--- a/config/urls.py
+++ b/config/urls.py
@@ -14,6 +14,7 @@ from cl8.users.api.views import (
     ProfileVcardView,
     ProfileEditView,
     ProfileCATJoinFormImportView,
+    ProfileCATAirtableImportView,
     TagAutoCompleteView,
     homepage,
 )
@@ -31,6 +32,11 @@ urlpatterns = [
         "profiles/<slug>/cat-joinform-import",
         ProfileCATJoinFormImportView.as_view(),
         name="profile-cat-joinform-import",
+    ),
+    path(
+        "profiles/<slug>/cat-airtable-import",
+        ProfileCATAirtableImportView.as_view(),
+        name="profile-cat-airtable-import",
     ),
     #
     # Django Admin, use {% url 'admin:index' %}

--- a/docs/setting-up-airtable.md
+++ b/docs/setting-up-airtable.md
@@ -1,0 +1,47 @@
+# Setting up integration with Airtable
+
+Constellate is designed to allow importing of informtion from an existing Airtable as a way to bootstrap a set of user profiles, or augment existing data if they already exist.
+
+https://pyairtable.readthedocs.io/en/stable/index.html) to connect to a predefined Airtable from the application, somewhat like the the Slack and Google Sheets Importers.
+
+Once you have defined which Airtable to query, which table in the Airtable, and set up necessary authentication credentials, you can perform a one way sync from the specified table into the database using the following management command:
+
+```
+./manage.py import_users_from_airtable
+```
+
+You have the option of making a per user import option avaibale for users, allowing them to run import information they have added, on their own schedule. This can be helpful to allow users control of what information they want to move across.
+
+## Defining which Airtable 'base' to fetch data from 
+
+
+The Airtable Base to fetch data from is defined by the AIRTABLE_BASE setting, which by default reads from the environment variable `DJANGO_AIRTABLE_BASE`. This should look like `appxxxxxxxxxxxxx`, where `x` is an alphanumeric character.
+
+Once you have specificed which base to connect to, the table to fetch the data from is defined by `AIRTABLE_TABLE`. Similarly, this value is defined by the environment variable `DJANGO_AIRTABLE_TABLE`.
+
+This should look like `tblxxxxxxxxxxxxxx` where `x` is an alphanumeric character.
+
+So, if you're on a Airtable page with the at the following kind of URL:
+
+https://airtable.com/appxxxxxxxxxxxxx/tblxxxxxxxxxxxxxx/viwxxxxxxxxxxxxxx?blocks=hide/
+
+You would set the spreadsheet key to be:
+
+```
+DJANGO_AIRTABLE_BASE="appxxxxxxxxxxxxx"
+DJANGO_AIRTABLE_TABLE="tblxxxxxxxxxxxxxx"
+```
+
+## Connecting with the correct credentials
+
+You will need a personal access token to connect to the Airtable defined above from the Django application. The fastest way to create a token is to follow Airtable's page below which will guide you through creating a token:
+
+https://airtable.com/developers/web/guides/personal-access-tokens
+
+
+Once you have a token, you can authenticate against Airtable's servers by setting the `AIRTABLE_BEARER_TOKEN` value, which by default reads from the environment variable
+ `DJANGO_AIRTABLE_BEARER_TOKEN` (seeing a pattern here?)
+
+ Once you have these set, you can run a bulk import, as well as individual imports. 
+ 
+ These both work up by updating an existing profile that matches the email address for the given row in the chosen table on Airtable. If there is no existing profile, the importer will create a new user and profile for that row.

--- a/justfile
+++ b/justfile
@@ -3,6 +3,10 @@
 # https://github.com/casey/just
 
 
+default:
+  just --list
+
+
 @test *options:
     pipenv run pytest {{options}}
 


### PR DESCRIPTION
This PR adds support for:

a) running a bulk import from a predefined table on Airtable.com, to either create or update existing profiles already in Constellate
b) Allowing end users to import the data they already added to the CAT directory Airtable.

This is intended to provide a smooth migration from the existing CAT directory Airtable, and allow members of CAT to update their own profile, as well as search and discover other members of CAT with complementary interests and skills.